### PR TITLE
New evolve

### DIFF
--- a/quspin/operators/ops.py
+++ b/quspin/operators/ops.py
@@ -1510,7 +1510,8 @@ class hamiltonian(object):
 			return self._imul_dense(other)
 
 
-
+	def __truediv__(self,other):
+		return self.__div__(other)
 
 	def __div__(self,other): # self / other
 		if isinstance(other,hamiltonian):			

--- a/quspin/tools/measurements.py
+++ b/quspin/tools/measurements.py
@@ -1104,7 +1104,7 @@ def obs_vs_time(psi_t,times,Obs_dict,return_state=False,Sent_args={}):
 
 
 	else:
-		psi = psi_t.next() # get first state from iterator.
+		psi = next(psi_t) # get first state from iterator.
 		# do first loop calculations
 		if psi.ndim == 2:
 			psi = psi.ravel()


### PR DESCRIPTION
for real hamiltonians `-1j*H(t).dot(V)` can be broken up as `V.real = H(t).dot(V.imag)` and `V.imag = -H(t).dot(V.real)`. It turns out that this is faster to do this and use scipy.integrate.ode then to do the current setup with scipy.integrate.complex_ode. the vector internally is organized such that V[:Ns]=V.real and V[Ns:]=V.imag and __SO_real does the Schroedinger operator on this structure. 

In evolve we add option `H_real` flag to evolve to activate this feature.  