### PR TITLE
added 'dense' kw arg for exp_op.get_mat 

### DIFF
--- a/quspin/operators/ops.py
+++ b/quspin/operators/ops.py
@@ -3036,12 +3036,14 @@ class exp_op(object):
 		self._iterate = Value
 		
 
-	def get_mat(self,time=0.0):
+	def get_mat(self,time=0.0,dense=False):
 
-		if self.O.is_dense:
+		if self.O.is_dense or dense:
 			return _np.linalg.expm(self._a * self.O.todense(time))
 		else:
 			return _sp.linalg.expm(self._a * self.O.tocsc(time))
+
+
 
 	def dot(self, other, time=0.0, shift=None):
 


### PR DESCRIPTION
to get a dense matrix from get_mat use the dense flag:

expO = exp_op(H,...).get_mat(...,dense=True/False)

if H is dense then this flag is ignored while if H is sparse, setting dense to true will cast the hamiltonian to dense and then calculate the exponential.
