### PR TITLE
Updated documentation to specify the basis used in the ent_entropy function

### DIFF
--- a/quspin/basis/base.py
+++ b/quspin/basis/base.py
@@ -297,6 +297,8 @@ class basis(object):
 
 			.. math::
 				S_\\mathrm{ent}(\\alpha) =  \\frac{1}{1-\\alpha}\\log \\mathrm{tr}_{A} \\left( \\mathrm{tr}_{A^c} \\vert\\psi\\rangle\\langle\\psi\\vert \\right)^\\alpha
+		
+			**Note:** The logarithm used is the natural logarithm (base e).
 		sparse_diag : bool, optional
 			When `sparse=True`, this flag enforces the use of
 			`scipy.sparse.linalg.eigsh() <https://docs.scipy.org/doc/scipy/reference/generated/generated/scipy.sparse.linalg.eigsh.html>`_

--- a/quspin/basis/basis_1d/fermion.py
+++ b/quspin/basis/basis_1d/fermion.py
@@ -529,6 +529,8 @@ class spinful_fermion_basis_1d(spinless_fermion_basis_1d,basis_1d):
 
 			.. math::
 				S_\\mathrm{ent}(\\alpha) =  \\frac{1}{1-\\alpha}\\log \\mathrm{tr}_{A} \\left( \\mathrm{tr}_{A^c} \\vert\\psi\\rangle\\langle\\psi\\vert \\right)^\\alpha
+		
+			**Note:** The logarithm used is the natural logarithm (base e).
 		sparse_diag : bool, optional
 			When `sparse=True`, this flag enforces the use of
 			`scipy.sparse.linalg.eigsh() <https://docs.scipy.org/doc/scipy/reference/generated/generated/scipy.sparse.linalg.eigsh.html>`_

--- a/quspin/basis/lattice.py
+++ b/quspin/basis/lattice.py
@@ -264,6 +264,8 @@ class lattice_basis(basis):
 
 			.. math::
 				S_\\mathrm{ent}(\\alpha) =  \\frac{1}{1-\\alpha}\\log \\mathrm{tr}_{A} \\left( \\mathrm{tr}_{A^c} \\vert\\psi\\rangle\\langle\\psi\\vert \\right)^\\alpha
+		
+			**Note:** The logarithm used is the natural logarithm (base e).
 		sparse_diag : bool, optional
 			When `sparse=True`, this flag enforces the use of
 			`scipy.sparse.linalg.eigsh() <https://docs.scipy.org/doc/scipy/reference/generated/generated/scipy.sparse.linalg.eigsh.html>`_

--- a/quspin/basis/photon.py
+++ b/quspin/basis/photon.py
@@ -559,6 +559,8 @@ class photon_basis(tensor_basis):
 
 			.. math::
 				S_\\mathrm{ent}(\\alpha) =  \\frac{1}{1-\\alpha}\\log \\mathrm{tr}_{A} \\left( \\mathrm{tr}_{A^c} \\vert\\psi\\rangle\\langle\\psi\\vert \\right)^\\alpha
+		
+			**Note:** The logarithm used is the natural logarithm (base e).
 		sparse_diag : bool, optional
 			When `sparse=True`, this flag enforces the use of
 			`scipy.sparse.linalg.eigsh() <https://docs.scipy.org/doc/scipy/reference/generated/generated/scipy.sparse.linalg.eigsh.html>`_

--- a/quspin/basis/tensor.py
+++ b/quspin/basis/tensor.py
@@ -491,6 +491,8 @@ class tensor_basis(basis):
 
 			.. math::
 				S_\\mathrm{ent}(\\alpha) =  \\frac{1}{1-\\alpha}\\log \\mathrm{tr}_{A} \\left( \\mathrm{tr}_{A^c} \\vert\\psi\\rangle\\langle\\psi\\vert \\right)^\\alpha
+		
+			**Note:** The logarithm used is the natural logarithm (base e).
 		sparse_diag : bool, optional
 			When `sparse=True`, this flag enforces the use of
 			`scipy.sparse.linalg.eigsh() <https://docs.scipy.org/doc/scipy/reference/generated/generated/scipy.sparse.linalg.eigsh.html>`_


### PR DESCRIPTION
Quite a trivial addition to the documentation, but sometimes people use other basises in the definition of the von Neuman entropy, i.e.:

http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.723.4261&rep=rep1&type=pdf

Took me a little bit until I had figured out why I couldn't quite reproduce the results from the paper (the numbers were slightly off). 