### PR TITLE
Upgrade make hamiltonian

### DIFF
--- a/quspin/basis/base.py
+++ b/quspin/basis/base.py
@@ -212,6 +212,15 @@ class basis(object):
 		"""
 		return self._Op(opstr,indx,J,dtype)
 
+	def _make_matrix(self,op_list,dtype):
+		""" takes list of operator strings and couplings to create matrix, this is the old niave way """
+		matrix = _sp.dia_matrix((self.Ns,self.Ns),dtype=dtype)
+		for opstr,indx,J in op_list:
+			ME,row,col = self.Op(opstr,indx,J,dtype)
+			matrix=matrix+_sp.csr_matrix((ME,(row,col)),shape=(self.Ns,self.Ns),dtype=dtype) 
+
+		return matrix
+
 
 	def partial_trace(self,state,sub_sys_A=None,subsys_ordering=True,return_rdm="A",enforce_pure=False,sparse=False):
 		"""Calculates reduced density matrix, through a partial trace of a quantum state in a lattice `basis`.

--- a/quspin/basis/basis_general/_basis_general_core/source/general_basis_matrix.h
+++ b/quspin/basis/basis_general/_basis_general_core/source/general_basis_matrix.h
@@ -1,0 +1,161 @@
+#ifndef _GENERAL_BASIS_MATRIX
+#define _GENERAL_BASIS_MATRIX
+
+#include <iostream>
+#include <complex>
+#include <algorithm>
+#include <map>
+#include <limits>
+#include "general_basis_core.h"
+#include "numpy/ndarraytypes.h"
+#include "misc.h"
+#include "openmp.h"
+#include <bits/stdc++.h>
+
+namespace basis_general {
+
+
+
+template<class T>
+int inline check_imag(std::complex<double> m,std::complex<T> *M){
+	M[0].real(m.real());
+	M[0].imag(m.imag());
+	return 0;
+}
+
+template<class T>
+int inline check_imag(std::complex<double> m,T *M){
+	if(std::abs(m.imag())>1.1e-15){
+		return 1;
+	}
+	else{
+		M[0] = m.real();
+		return 0;
+	}
+}
+
+
+
+template<class I, class J, class K, class T>
+int general_make_matrix(general_basis_core<I> *B,
+						  const int n_ops,
+						  const std::vector<std::string> opstrs,
+						  const std::vector<std::vector<int>> indxs,
+						  const std::vector<std::complex<double>> Js,
+						  const bool full_basis,
+						  const npy_intp Ns,
+						  const I basis[],
+						  const J n[],
+								std::vector<I> indptr,
+								std::vector<I> indices,
+								std::vector<T> data
+						  )
+{
+	indptr.resize(Ns+1);
+	indices.resize(0);
+	data.resize(0);
+
+	std::fill(indptr.begin(),indptr.end(),(I)0);
+	npy_intp nnz = 0;
+	npy_intp row_size_avg = 0;
+	int err = 0;
+	std::map<I,T> row_data;
+
+	for(npy_intp i=0;i<Ns && err==0;j++){
+		row_data.clear();	
+
+		for(int iop=0;iop<n_ops && err==0;j++){
+			std::string opstr = opstrs[iop];
+			std::vector<int> indx = indxs[iop];
+			const int n_op = indx.size();
+			std::reverse(indx.begin(),indx.end());
+			std::reverse(opstr.begin(),opstr.end());
+
+			I r = basis[i];
+			K j = i;
+
+			std::complex<double> m = Js[iop];
+			err = B->op(r,m,n_op,opstr.c_str(),&indx[0]);
+
+
+
+			int sign = 1;
+
+			for(int k=0;k<nt;k++){
+				g[k]=0;
+			}
+
+			
+			if(r != basis[j]){
+				I rr = B->ref_state(r,g,sign);
+				if(full_basis){
+					j = Ns - (npy_intp)rr - 1;
+				}
+				else{
+					j = binary_search(Ns,basis,rr);
+				}
+				
+			}
+
+			if(j >= 0){
+				T M = 0;
+
+				for(int k=0;k<nt;k++){
+					double q = (2.0*M_PI*B->qs[k]*g[k])/B->pers[k];
+					m *= std::exp(std::complex<double>(0,-q));
+				}
+
+				m *= sign * std::sqrt(double(n[i])/double(n[j]));
+
+				err = check_imag(m,&M);
+
+				if(row_data.count(j)){ // if column element exists add to matrix element
+					row_data[j] += M;
+				}
+				else{ // else create new column entry
+					row_data[j] = M;
+				}
+			}
+		}
+
+		// add matrix elements to csr data.
+		const int row_size = row_data.size();
+		const npy_intp capacity = indices.capacity();
+
+		// running average of row_size
+		if(i>0){
+			row_size_avg = row_size_avg + (npy_intp)((row_size_avg - row_size)/(i+1));
+		}else{
+			row_size_avg = row_size;
+		}
+		
+
+		nnz += row_size;
+		indptr[i+1] = nnz;
+
+		// use running average of row_size to allocate more memory. 
+		if(nnz > capacity){
+			npy_intp new_capacity = nnz + std::max((Ns*row_size_avg/100),(npy_intp)1);
+			indices.reserve(new_capacity);
+			data.reserve(new_capacity);
+		}
+
+		// add column indices and data to arrays
+		std::map<I,T>::iterator it = row_data.begin();
+
+		for(I j=indptr[i];j<indptr[i+1];++j){
+			indices.push_back(it->first);
+			data[j].push_back(it->second);
+			++it;
+		}
+	}
+
+	return err;
+}
+
+
+}
+
+
+
+#endif

--- a/quspin/basis/basis_general/_basis_general_core/source/general_basis_op.h
+++ b/quspin/basis/basis_general/_basis_general_core/source/general_basis_op.h
@@ -52,7 +52,7 @@ int general_op(general_basis_core<I> *B,
 	#pragma omp parallel 
 	{
 		const int nt = B->get_nt();
-		const npy_intp chunk = std::max(Ns/(100*omp_get_num_threads()),(npy_intp)1);
+		const npy_intp chunk = std::max(Ns/(1000*omp_get_num_threads()),(npy_intp)1);
 		int g[__GENERAL_BASIS_CORE__max_nt];
 
 		#pragma omp for schedule(dynamic,chunk)
@@ -160,9 +160,9 @@ int general_inplace_op(general_basis_core<I> *B,
 	#pragma omp parallel
 	{
 		const int nt = B->get_nt();
-		const npy_intp chunk = std::max(Ns/(100*omp_get_num_threads()),(npy_intp)1);
 		int g[__GENERAL_BASIS_CORE__max_nt];
-		#pragma omp for schedule(dynamic,chunk)
+		
+		#pragma omp for schedule(static)
 		for(npy_intp i=0;i<Ns;i++){
 			if(err != 0){
 				continue;
@@ -273,10 +273,9 @@ int general_op_bra_ket(general_basis_core<I> *B,
 	#pragma omp parallel
 	{
 		const int nt = B->get_nt();
-		const npy_intp chunk = std::max(Ns/(100*omp_get_num_threads()),(npy_intp)1);
 		int g[__GENERAL_BASIS_CORE__max_nt];
 			
-		#pragma omp for schedule(dynamic,chunk)
+		#pragma omp for schedule(static)
 		for(npy_intp i=0;i<Ns;i++){
 			if(err != 0){
 				continue;
@@ -359,10 +358,9 @@ int general_op_bra_ket_pcon(general_basis_core<I> *B,
 	{
 		const std::set<std::vector<int>> Np_set_local = Np_set;
 		const int nt = B->get_nt();
-		const npy_intp chunk = std::max(Ns/(100*omp_get_num_threads()),(npy_intp)1);
 		int g[__GENERAL_BASIS_CORE__max_nt];
 		
-		#pragma omp for schedule(dynamic,chunk) 
+		#pragma omp for schedule(static) 
 		for(npy_intp i=0;i<Ns;i++){
 			if(err != 0){
 				continue;


### PR DESCRIPTION
This moves the matrix construction from _make_hamiltonian.py into the basis class. This allows for a future upgrades where we can construct the matrix in C++ if we want. 

Also I've split the construction into two parts, a diagonal part and off-diagonal part. The diagonal matrix elements are stored as an array after a check is performed to see if the matrix elements are all diagonal. 

The reason for doing this is typically matrix elements will either be totally diagonal or have mostly off diagonal elements and so for the diagonal matrix elements just checking to see if they are all diagonal and storing the results inside an array is much faster than doing a csr_matrix addition. 