### PR TITLE
change 'from scipy.misc import comb' to 'scipy.special import comb'

### DIFF
--- a/quspin/basis/basis_1d/_basis_1d_core/basis_ops.py
+++ b/quspin/basis/basis_1d/_basis_1d_core/basis_ops.py
@@ -1,5 +1,6 @@
 import numpy as _np
-from scipy.misc import comb
+#from scipy.misc import comb
+from scipy.special import comb
 
 # tells whether or not the inputs into the ops needs Ns or 2*Ns elements
 """

--- a/quspin/basis/basis_1d/_basis_1d_core/boson_basis.pyx
+++ b/quspin/basis/basis_1d/_basis_1d_core/boson_basis.pyx
@@ -14,7 +14,7 @@ from types cimport *
 
 
 import numpy as _np
-from scipy.misc import comb
+from scipy.special import comb
 
 cdef extern from "glibc_fix.h":
     pass

--- a/quspin/basis/basis_1d/_basis_1d_core/boson_ops.pyx
+++ b/quspin/basis/basis_1d/_basis_1d_core/boson_ops.pyx
@@ -14,7 +14,7 @@ from types cimport *
 
 
 import numpy as _np
-from scipy.misc import comb
+from scipy.special import comb
 
 cdef extern from "glibc_fix.h":
     pass

--- a/quspin/basis/basis_1d/_basis_1d_core/hcp_basis.pyx
+++ b/quspin/basis/basis_1d/_basis_1d_core/hcp_basis.pyx
@@ -14,7 +14,8 @@ from types cimport *
 
 
 import numpy as _np
-from scipy.misc import comb
+#from scipy.misc import comb
+from scipy.special import comb
 
 cdef extern from "glibc_fix.h":
     pass

--- a/quspin/basis/basis_1d/_basis_1d_core/hcp_ops.pyx
+++ b/quspin/basis/basis_1d/_basis_1d_core/hcp_ops.pyx
@@ -14,7 +14,8 @@ from types cimport *
 
 
 import numpy as _np
-from scipy.misc import comb
+#from scipy.misc import comb
+from scipy.special import comb
 
 cdef extern from "glibc_fix.h":
     pass

--- a/quspin/basis/basis_1d/_basis_1d_core/spf_basis.pyx
+++ b/quspin/basis/basis_1d/_basis_1d_core/spf_basis.pyx
@@ -14,7 +14,7 @@ from types cimport *
 
 
 import numpy as _np
-from scipy.misc import comb
+from scipy.special import comb
 
 cdef extern from "glibc_fix.h":
     pass

--- a/quspin/basis/basis_1d/_basis_1d_core/spf_ops.pyx
+++ b/quspin/basis/basis_1d/_basis_1d_core/spf_ops.pyx
@@ -14,7 +14,8 @@ from types cimport *
 
 
 import numpy as _np
-from scipy.misc import comb
+#from scipy.misc import comb
+from scipy.special import comb 
 
 cdef extern from "glibc_fix.h":
     pass

--- a/quspin/basis/basis_general/_basis_general_core/boson_core.pyx
+++ b/quspin/basis/basis_general/_basis_general_core/boson_core.pyx
@@ -1,7 +1,8 @@
 # cython: language_level=2
 # distutils: language=c++
 import cython
-from scipy.misc import comb
+from scipy.special import comb
+
 import scipy.sparse as _sp
 cimport numpy as _np
 import numpy as _np

--- a/quspin/basis/basis_general/_basis_general_core/hcb_core.pyx
+++ b/quspin/basis/basis_general/_basis_general_core/hcb_core.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=2
 # distutils: language=c++
 import cython
-from scipy.misc import comb
+from scipy.special import comb
 import scipy.sparse as _sp
 cimport numpy as _np
 import numpy as _np

--- a/quspin/basis/basis_general/_basis_general_core/higher_spin_core.pyx
+++ b/quspin/basis/basis_general/_basis_general_core/higher_spin_core.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=2
 # distutils: language=c++
 import cython
-from scipy.misc import comb
+from scipy.special import comb
 import scipy.sparse as _sp
 cimport numpy as _np
 import numpy as _np

--- a/quspin/basis/basis_general/_basis_general_core/spinful_fermion_core.pyx
+++ b/quspin/basis/basis_general/_basis_general_core/spinful_fermion_core.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=2
 # distutils: language=c++
 import cython
-from scipy.misc import comb
+from scipy.special import comb
 import scipy.sparse as _sp
 cimport numpy as _np
 import numpy as _np

--- a/quspin/basis/basis_general/_basis_general_core/spinless_fermion_core.pyx
+++ b/quspin/basis/basis_general/_basis_general_core/spinless_fermion_core.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=2
 # distutils: language=c++
 import cython
-from scipy.misc import comb
+from scipy.special import comb
 import scipy.sparse as _sp
 
 include "source/general_basis_core.pyx"

--- a/quspin/basis/basis_general/base_hcb.py
+++ b/quspin/basis/basis_general/base_hcb.py
@@ -2,7 +2,7 @@ from ._basis_general_core import hcb_basis_core_wrap
 from ._basis_general_core import get_basis_type,basis_zeros
 from .base_general import basis_general
 import numpy as _np
-from scipy.misc import comb
+from scipy.special import comb
 import cProfile
 
 # general basis for hardcore bosons/spin-1/2

--- a/quspin/basis/basis_general/base_higher_spin.py
+++ b/quspin/basis/basis_general/base_higher_spin.py
@@ -2,7 +2,7 @@ from ._basis_general_core import higher_spin_basis_core_wrap,get_basis_type,basi
 from .base_general import basis_general
 from .boson import H_dim
 import numpy as _np
-from scipy.misc import comb
+from scipy.special import comb
 
 
 

--- a/quspin/basis/basis_general/boson.py
+++ b/quspin/basis/basis_general/boson.py
@@ -2,8 +2,7 @@ from ._basis_general_core import boson_basis_core_wrap,get_basis_type,basis_zero
 from .base_hcb import hcb_basis_general
 from .base_general import basis_general
 import numpy as _np
-from scipy.misc import comb
-
+from scipy.special import comb
 
 def H_dim(N,length,m_max):
     """

--- a/quspin/basis/basis_general/fermion.py
+++ b/quspin/basis/basis_general/fermion.py
@@ -4,7 +4,7 @@ from ._basis_general_core import get_basis_type,basis_zeros
 from .base_general import basis_general,_check_symm_map
 from ..base import MAXPRINT
 import numpy as _np
-from scipy.misc import comb
+from scipy.special import comb
 
 
 # general basis for hardcore bosons/spin-1/2


### PR DESCRIPTION
I just installed QuSpin under py3.7.4 without using conda. The installation succeeded, but it raised error when import quspin in the python interpreter or ipython as follows:  

ImportError                               Traceback (most recent call last)
<ipython-input-1-7573c2381c55> in <module>
----> 1 import quspin

~/Dropbox/downloads/QuSpin/quspin/__init__.py in <module>
      1 # local modules
      2 import numpy,dill
----> 3 from . import operators
      4 from . import basis
      5 from . import tools

~/Dropbox/downloads/QuSpin/quspin/operators/__init__.py in <module>
     50 
     51 """
---> 52 from .quantum_operator_core import *
     53 from .quantum_LinearOperator_core import *
     54 from .hamiltonian_core import *

~/Dropbox/downloads/QuSpin/quspin/operators/quantum_operator_core.py in <module>
      1 from __future__ import print_function, division, absolute_import
      2 
----> 3 from ..basis import spin_basis_1d as _default_basis
      4 from ..basis import isbasis as _isbasis
      5 

~/Dropbox/downloads/QuSpin/quspin/basis/__init__.py in <module>
    106    bitwise_rightshift
    107 """
--> 108 from .basis_1d import *
    109 from .basis_general import *
    110 from .base import *

~/Dropbox/downloads/QuSpin/quspin/basis/basis_1d/__init__.py in <module>
----> 1 from .spin import spin_basis_1d
      2 from .boson import boson_basis_1d
      3 from .fermion import spinless_fermion_basis_1d,spinful_fermion_basis_1d

~/Dropbox/downloads/QuSpin/quspin/basis/basis_1d/spin.py in <module>
----> 1 from ._basis_1d_core import hcp_basis,hcp_ops
      2 from ._basis_1d_core import boson_basis,boson_ops
      3 from .base_1d import basis_1d
      4 import numpy as _np
      5 

~/Dropbox/downloads/QuSpin/quspin/basis/basis_1d/_basis_1d_core/__init__.py in <module>
----> 1 from . import hcp_basis,hcp_ops
      2 from . import boson_basis,boson_ops
      3 from . import spf_basis,spf_ops

~/Dropbox/downloads/QuSpin/quspin/basis/basis_1d/_basis_1d_core/hcp_basis.pyx in init quspin.basis.basis_1d._basis_1d_core.hcp_basis()

ImportError: cannot import name comb


The reason is that "comb is deprecated! Importing comb from scipy.misc is deprecated in scipy 1.0.0. Use scipy.special.comb instead."  See  the doc of scipy https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.misc.comb.html
