### PR TITLE
Add example13: complex geometry via networkx

### DIFF
--- a/examples/scripts/example13.py
+++ b/examples/scripts/example13.py
@@ -1,0 +1,53 @@
+###########################################################################
+#                            example 13                                   #	
+# This example exploits networkx for building a connectivity graph        #
+# representing the hexagonal lattice geometry for the 2 species           #
+# Fermy-Hubbard model.                                                    #
+###########################################################################
+
+# %% libraries
+
+import numpy as np
+import networkx as nx
+
+from quspin.basis import spinful_fermion_basis_general
+from quspin.operators import hamiltonian
+
+# %% parameters
+
+L_x, L_y = 2, 2             # lattice sizes
+N_up, N_dn = 2, 2           # number of up/down spin particles
+t, U = 1.0, 2.0             # tunneling and interaction
+
+# %% build graph
+
+G = nx.generators.lattice.hexagonal_lattice_graph(L_x, L_y)
+L = G.number_of_nodes()
+
+# label nodes from 0 to L-1 for convenience
+G = nx.convert_node_labels_to_integers(G)
+
+# show the graph
+nx.draw(G, with_labels=True)
+
+# %% build basis & Hamiltonian
+
+basis = spinful_fermion_basis_general(L, Nf=(N_up, N_dn))
+
+interactions = [[U, i, i] for i in range(L)]
+tunnelling = []
+for i in range(L):
+    tunnelling += [[-t, i, j] for j in G.adj[i]]
+
+static = [
+    ["n|n", interactions],
+    ["+-|", tunnelling],
+    ["|+-", tunnelling]]
+
+checks = dict(check_pcon=True, check_symm=True, check_herm=True)
+
+H = hamiltonian(static, [], basis=basis, dtype=np.float64, **checks)
+
+# %% do some interesting stuff...
+
+E = H.eigvalsh()

--- a/examples/scripts/example18.py
+++ b/examples/scripts/example18.py
@@ -1,5 +1,5 @@
 ###########################################################################
-#                            example 13                                   #	
+#                            example 18                                   #	
 # This example exploits networkx for building a connectivity graph        #
 # representing the hexagonal lattice geometry for the 2 species           #
 # Fermy-Hubbard model.                                                    #

--- a/examples/scripts/example18.py
+++ b/examples/scripts/example18.py
@@ -2,7 +2,8 @@
 #                            example 18                                   #	
 # This example exploits networkx for building a connectivity graph        #
 # representing the hexagonal lattice geometry for the 2 species           #
-# Fermy-Hubbard model.                                                    #
+# Fermy-Hubbard model. Using the same syntax one can use many other       #
+# predefined geometries from networkx.                                    #
 ###########################################################################
 
 # %% libraries
@@ -13,41 +14,40 @@ import networkx as nx
 from quspin.basis import spinful_fermion_basis_general
 from quspin.operators import hamiltonian
 
+import matplotlib.pyplot as plt
+
 # %% parameters
 
-L_x, L_y = 2, 2             # lattice sizes
-N_up, N_dn = 2, 2           # number of up/down spin particles
-t, U = 1.0, 2.0             # tunneling and interaction
+m, n = 2, 2                 # hexagonal lattice sizes
+isPBC = False               # if True, use periodic boundary conditions
+N_up, N_dn = 1, 1           # number of up/down fermions
+t, U = 1.0, 2.0             # tunneling and interaction of fermions
 
 # %% build graph
 
-G = nx.generators.lattice.hexagonal_lattice_graph(L_x, L_y)
-L = G.number_of_nodes()
+G = nx.generators.lattice.hexagonal_lattice_graph(m, n, periodic=isPBC)
+N = G.number_of_nodes()
 
-# label nodes from 0 to L-1 for convenience
+# 0-index nodes for quspin
 G = nx.convert_node_labels_to_integers(G)
 
-# show the graph
-nx.draw(G, with_labels=True)
+# visualise
+pos = nx.spring_layout(G, seed=42, iterations=100)
+nx.draw(G, pos=pos, with_labels=True)
+plt.show()
 
 # %% build basis & Hamiltonian
 
-basis = spinful_fermion_basis_general(L, Nf=(N_up, N_dn))
+basis = spinful_fermion_basis_general(N, Nf=(N_up, N_dn))
 
-interactions = [[U, i, i] for i in range(L)]
-tunnelling = []
-for i in range(L):
-    tunnelling += [[-t, i, j] for j in G.adj[i]]
+interactions = [[U, i, i] for i in range(N)]
+tunnelling = [[-t, i, j] for i in range(N) for j in G.adj[i]]
 
-static = [
-    ["n|n", interactions],
-    ["+-|", tunnelling],
-    ["|+-", tunnelling]]
+static = [["n|n", interactions], ["+-|", tunnelling], ["|+-", tunnelling]]
 
-checks = dict(check_pcon=True, check_symm=True, check_herm=True)
+H = hamiltonian(static, [], basis=basis, dtype=np.float64)
 
-H = hamiltonian(static, [], basis=basis, dtype=np.float64, **checks)
+# %% solve eigenproblem
 
-# %% do some interesting stuff...
-
-E = H.eigvalsh()
+E, V = H.eigsh()
+print(f'First eigenvalues: {E}')


### PR DESCRIPTION
Hi @mgbukov, here's an example as you suggested in #234 that might close the issue.

I have an related question though. I was wondering if there's any difference in using `*_basis_1d` vs its counterpart `*_basis_general` in case if we don't add any geometry-based symmetries? It seems to me that `*_basis_1d` should be a child class of `*_basis_general` with predefined symmetries in 1D, but I didn't managed to see it after a quick code review. Is there something I should be aware while switching between those two?