### PR TITLE
Relaxing dtype

### DIFF
--- a/quspin/basis/basis_general/_basis_general_core/setup.py
+++ b/quspin/basis/basis_general/_basis_general_core/setup.py
@@ -27,8 +27,8 @@ def cython_files():
     package_dir = os.path.dirname(os.path.realpath(__file__))
     package_dir = os.path.expandvars(package_dir)
 
-    cython_src = glob.glob(os.path.join(package_dir,"*.pyx"))
-    # cython_src = [os.path.join(package_dir,"hcb_core.pyx"),os.path.join(package_dir,"higher_spin_core.pyx")]
+    # cython_src = glob.glob(os.path.join(package_dir,"*.pyx"))
+    cython_src = [os.path.join(package_dir,"hcb_core.pyx")]
     # cython_src = [os.path.join(package_dir,"general_basis_utils.pyx")]
 
     include_dir = os.path.join(package_dir,"source")

--- a/quspin/basis/basis_general/_basis_general_core/setup.py
+++ b/quspin/basis/basis_general/_basis_general_core/setup.py
@@ -27,8 +27,8 @@ def cython_files():
     package_dir = os.path.dirname(os.path.realpath(__file__))
     package_dir = os.path.expandvars(package_dir)
 
-    # cython_src = glob.glob(os.path.join(package_dir,"*.pyx"))
-    cython_src = [os.path.join(package_dir,"hcb_core.pyx")]
+    cython_src = glob.glob(os.path.join(package_dir,"*.pyx"))
+    # cython_src = [os.path.join(package_dir,"hcb_core.pyx")]
     # cython_src = [os.path.join(package_dir,"general_basis_utils.pyx")]
 
     include_dir = os.path.join(package_dir,"source")

--- a/quspin/basis/basis_general/_basis_general_core/source/general_basis_core.pxd
+++ b/quspin/basis/basis_general/_basis_general_core/source/general_basis_core.pxd
@@ -2,6 +2,7 @@
 from general_basis_types cimport *
 from libcpp.vector cimport vector
 from libcpp.set cimport set
+from libcpp.utility cimport pair
 from numpy cimport PyArray_Descr,PyArray_DESCR,ndarray
 import numpy as _np
 
@@ -19,9 +20,9 @@ cdef extern from "make_general_basis.h" namespace "basis_general":
     int general_make_basis_blocks[I](general_basis_core[I] *B,const int,const npy_intp,const I[],npy_intp[],npy_intp[]) nogil
 
 cdef extern from "general_basis_op.h" namespace "basis_general":
-    int general_op[I,J,K,T](general_basis_core[I] *B,const int,const char[], const int[],
-                          const double complex, const bool, const npy_intp, const I[], const J[],
-                          const npy_intp[],const npy_intp[],const int,npy_intp&, K[], K[], T[]) nogil
+    pair[int,int] general_op[I,J,K,T](general_basis_core[I] *B,const int,const char[], const int[],
+                                      const double complex, const bool, const npy_intp, const I[], const J[],
+                                      const npy_intp[],const npy_intp[],const int, K[], K[], T[]) nogil
 
     int general_inplace_op_impl[I,J](general_basis_core[I] *B,const bool,const bool,const int,const char[], 
                           const int[],void*, const bool, const npy_intp,const npy_intp, const I[], const J[],

--- a/quspin/basis/basis_general/_basis_general_core/source/general_basis_core.pyx
+++ b/quspin/basis/basis_general/_basis_general_core/source/general_basis_core.pyx
@@ -5,8 +5,10 @@ from libc.math cimport cos,sin,abs,sqrt
 import scipy.sparse as _sp
 cimport numpy as _np
 import numpy as _np
+import warnings
 from libcpp.vector cimport vector
 from libcpp.set cimport set
+from libcpp.utility cimport pair
 
 from .general_basis_utils import uint32,uint64,uint256,uint1024,uint4096,uint16384
 
@@ -28,7 +30,7 @@ cdef get_proj_helper(general_basis_core[npy_uint] * B, npy_uint * basis, int nt,
         for j in range(per):
             if dtype is float or dtype is double:
                 if abs(cc.imag)>1.1e-15:
-                    raise TypeError("attemping to use real type for complex elements.")
+                    raise TypeError("attempting to use real type for complex elements.")
 
                 P = get_proj_helper(B,basis,nt,nnt-1,sign,c,indices,indptr,P)
                 with nogil:
@@ -48,7 +50,7 @@ cdef get_proj_helper(general_basis_core[npy_uint] * B, npy_uint * basis, int nt,
         for j in range(per):
             if dtype is float or dtype is double:
                 if abs(cc.imag)>1.1e-15:
-                    raise TypeError("attemping to use real type for complex elements.")
+                    raise TypeError("attempting to use real type for complex elements.")
 
                 with nogil:
                     for i in range(Ns):
@@ -98,7 +100,7 @@ cdef get_proj_pcon_helper(general_basis_core[state_type] * B, state_type * basis
         for j in range(per):
             if dtype is float or dtype is double:
                 if abs(cc.imag)>1.1e-15:
-                    raise TypeError("attemping to use real type for complex elements.")
+                    raise TypeError("attempting to use real type for complex elements.")
 
                 P = get_proj_pcon_helper(B,basis,nt,nnt-1,sign,c,indices,indptr,basis_pcon,P)
                 with nogil:
@@ -118,7 +120,7 @@ cdef get_proj_pcon_helper(general_basis_core[state_type] * B, state_type * basis
         for j in range(per):
             if dtype is float or dtype is double:
                 if abs(cc.imag)>1.1e-15:
-                    raise TypeError("attemping to use real type for complex elements.")
+                    raise TypeError("attempting to use real type for complex elements.")
 
                 with nogil:
                     for i in range(Ns):
@@ -224,11 +226,10 @@ cdef class general_basis_core_wrap:
         cdef int n_op = indx.shape[0]
         cdef npy_intp Ns = basis.shape[0]
         cdef bool basis_full = self._Ns_full == basis.shape[0]
-        cdef int err = 0;
+        cdef pair[int,int] err;
         cdef double complex JJ = J
         cdef void * basis_ptr = _np.PyArray_DATA(basis) # use standard numpy API function
         cdef void * B = self._basis_core # must define local cdef variable to do the pointer casting
-        cdef npy_intp N_me = 0;
 
         if not basis.flags["CARRAY"]:
             raise ValueError("basis array must be writable and C-contiguous")
@@ -236,39 +237,37 @@ cdef class general_basis_core_wrap:
         if basis.dtype == uint32:
             with nogil:
                 err = general_op(<general_basis_core[uint32_t]*>B,n_op,&c_opstr[0],&indx[0],JJ,
-                    basis_full,Ns,<uint32_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,N_me,&row[0],&col[0],&M[0])
+                    basis_full,Ns,<uint32_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,&row[0],&col[0],&M[0])
         elif basis.dtype == uint64:
             with nogil:
                 err = general_op(<general_basis_core[uint64_t]*>B,n_op,&c_opstr[0],&indx[0],JJ,
-                    basis_full,Ns,<uint64_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,N_me,&row[0],&col[0],&M[0])
+                    basis_full,Ns,<uint64_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,&row[0],&col[0],&M[0])
         elif basis.dtype == uint256:
             with nogil:
                 err = general_op(<general_basis_core[uint256_t]*>B,n_op,&c_opstr[0],&indx[0],JJ,
-                    basis_full,Ns,<uint256_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,N_me,&row[0],&col[0],&M[0])
+                    basis_full,Ns,<uint256_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,&row[0],&col[0],&M[0])
         elif basis.dtype == uint1024:
             with nogil:
                 err = general_op(<general_basis_core[uint1024_t]*>B,n_op,&c_opstr[0],&indx[0],JJ,
-                    basis_full,Ns,<uint1024_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,N_me,&row[0],&col[0],&M[0])
+                    basis_full,Ns,<uint1024_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,&row[0],&col[0],&M[0])
         elif basis.dtype == uint4096:
             with nogil:
                 err = general_op(<general_basis_core[uint4096_t]*>B,n_op,&c_opstr[0],&indx[0],JJ,
-                    basis_full,Ns,<uint4096_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,N_me,&row[0],&col[0],&M[0])
+                    basis_full,Ns,<uint4096_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,&row[0],&col[0],&M[0])
         elif basis.dtype == uint16384:
             with nogil:
                 err = general_op(<general_basis_core[uint16384_t]*>B,n_op,&c_opstr[0],&indx[0],JJ,
-                    basis_full,Ns,<uint16384_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,N_me,&row[0],&col[0],&M[0])
+                    basis_full,Ns,<uint16384_t*>basis_ptr,&n[0],&basis_begin[0],&basis_end[0],N_p,&row[0],&col[0],&M[0])
         else:
             raise TypeError("basis dtype {} not recognized.".format(basis.dtype))
 
 
-        if err == -1:
+        if err.first == -1:
             raise ValueError("operator not recognized.")
-        elif err == 1:
-            raise TypeError("attemping to use real type for complex matrix elements.")
-        elif err != 0:
-            raise RuntimeError("user defined error code: {}".format(err))
-
-        return N_me
+        elif err.second == 1:
+            warnings.warn("attempting to use real type for complex matrix elements.",_np.ComplexWarning,stacklevel=4)
+        elif err.first != 0:
+            raise RuntimeError("user defined error code: {}".format(err.first))
  
     @cython.boundscheck(False)
     def op_shift_sector(self, dtype[:,::1] v_in, dtype[:,::1] v_out, object opstr,int[::1] indx, object J,
@@ -430,7 +429,7 @@ cdef class general_basis_core_wrap:
         if err == -1:
             raise ValueError("operator not recognized.")
         elif err == 1:
-            raise TypeError("attemping to use real type for complex matrix elements.")
+            raise TypeError("attempting to use real type for complex matrix elements.")
         elif err != 0:
             raise RuntimeError("user defined error code: {}".format(err))
 
@@ -493,7 +492,7 @@ cdef class general_basis_core_wrap:
         if err == -1:
             raise ValueError("operator not recognized.")
         elif err == 1:
-            raise TypeError("attemping to use real type for complex matrix elements.")
+            raise TypeError("attempting to use real type for complex matrix elements.")
         elif err == -2:
             raise TypeError("input datatype is not single or double precision floating point types.")
 
@@ -553,7 +552,7 @@ cdef class general_basis_core_wrap:
                 raise TypeError("basis dtype {} not recognized.".format(basis.dtype))
 
         if not err:
-            raise TypeError("attemping to use real type for complex elements.")
+            raise TypeError("attempting to use real type for complex elements.")
 
 
     @cython.boundscheck(False)
@@ -612,7 +611,7 @@ cdef class general_basis_core_wrap:
                 raise TypeError("basis dtype {} not recognized.".format(basis.dtype))
 
         if not err:
-            raise TypeError("attemping to use real type for complex elements.")
+            raise TypeError("attempting to use real type for complex elements.")
 
     @cython.boundscheck(False)
     def get_proj(self, _np.ndarray basis, object Ptype,int8_t[::1] sign, dtype[::1] c, index_type[::1] indices, index_type[::1] indptr,_np.ndarray basis_pcon = None):
@@ -877,7 +876,7 @@ cdef class general_basis_core_wrap:
         if err == -1:
             raise ValueError("operator not recognized.")
         elif err == 1:
-            raise TypeError("attemping to use real type for complex matrix elements.")
+            raise TypeError("attempting to use real type for complex matrix elements.")
         elif err != 0:
             raise RuntimeError("user defined error code: {}".format(err))
 
@@ -1022,7 +1021,7 @@ cdef class general_basis_core_wrap:
         
 
         if err > 0:
-            raise TypeError("attemping to use real type for complex matrix elements.")
+            raise TypeError("attempting to use real type for complex matrix elements.")
 
 
 

--- a/quspin/basis/basis_general/_basis_general_core/source/general_basis_get_amp.h
+++ b/quspin/basis/basis_general/_basis_general_core/source/general_basis_get_amp.h
@@ -98,7 +98,7 @@ int get_amp_general(general_basis_core<I,P> *B,
 					out_tmp = 0.0;
 				}
 
-				int local_err = check_imag(out_tmp, &out[i]); // compute and assign amplitude in full basis
+				int local_err = type_checks(out_tmp, &out[i]); // compute and assign amplitude in full basis
 				if(local_err){
 					#pragma omp critical
 					err = local_err;
@@ -135,7 +135,7 @@ int get_amp_general(general_basis_core<I,P> *B,
 					out_tmp = 0.0;
 				}
 
-				int local_err = check_imag(out_tmp, &out[i]); // compute and assign amplitude in full basis
+				int local_err = type_checks(out_tmp, &out[i]); // compute and assign amplitude in full basis
 				if(local_err){
 					#pragma omp critical
 					err = local_err;
@@ -194,7 +194,7 @@ int get_amp_general_light(general_basis_core<I,P> *B,
 				phase_factor = get_amp_rep(B,nt,ss,ss);
 				out_tmp = phase_factor/std::sqrt(norm_r * per_factor);
 				
-				int local_err = check_imag(out_tmp, &out[i]); // compute and assign amplitude in full basis
+				int local_err = type_checks(out_tmp, &out[i]); // compute and assign amplitude in full basis
 				if(local_err){
 					#pragma omp critical
 					err = local_err;
@@ -216,7 +216,7 @@ int get_amp_general_light(general_basis_core<I,P> *B,
 
 				out_tmp = std::sqrt(norm_r/per_factor);
 				
-				int local_err = check_imag(out_tmp, &out[i]); // compute and assign amplitude in full basis
+				int local_err = type_checks(out_tmp, &out[i]); // compute and assign amplitude in full basis
 				if(local_err){
 					#pragma omp critical
 					err = local_err;

--- a/quspin/basis/basis_general/_basis_general_core/source/misc.h
+++ b/quspin/basis/basis_general/_basis_general_core/source/misc.h
@@ -102,17 +102,17 @@ inline std::complex<double> mul(T a,std::complex<double> z){
 
 
 template<class T>
-int inline check_imag(const std::complex<double> m){
+int inline type_checks(const std::complex<double> m){
 	return 0;
 }
 
 template<>
-int inline check_imag<double>(const std::complex<double> m){
+int inline type_checks<double>(const std::complex<double> m){
 	return (std::abs(m.imag())>1.1e-15 ? 1 : 0);
 }
 
 template<>
-int inline check_imag<float>(const std::complex<double> m){
+int inline type_checks<float>(const std::complex<double> m){
 	return (std::abs(m.imag())>1.1e-15 ? 1 : 0);
 }
 
@@ -121,20 +121,20 @@ int inline check_imag<float>(const std::complex<double> m){
 
 
 template<class T>
-int inline check_imag(const std::complex<double> m,std::complex<T> *M){
+int inline type_checks(const std::complex<double> m,std::complex<T> *M){
 	M->real(m.real());
 	M->imag(m.imag());
 	return 0;
 }
 
 template<class T>
-int inline check_imag(const std::complex<double> m,T *M){
+int inline type_checks(const std::complex<double> m,T *M){
 	(*M) = m.real();
 	return (std::abs(m.imag())>1.1e-15 ? 1 : 0);
 }
 
 // template<>
-// int inline check_imag<signed char>(const std::complex<double> m,signed char *M){
+// int inline type_checks<signed char>(const std::complex<double> m,signed char *M){
 // 	const double real = m.real();
 // 	*M = (signed char) real;
 
@@ -151,7 +151,7 @@ int inline check_imag(const std::complex<double> m,T *M){
 // }
 
 // template<>
-// int inline check_imag<signed short>(const std::complex<double> m,signed short *M){
+// int inline type_checks<signed short>(const std::complex<double> m,signed short *M){
 // 	const double real = m.real();
 // 	*M = (signed short) real;
 
@@ -169,14 +169,14 @@ int inline check_imag(const std::complex<double> m,T *M){
 
 
 template<class T>
-int inline check_imag(const std::complex<double> m,const std::complex<T> v,std::complex<T> *M){
+int inline type_checks(const std::complex<double> m,const std::complex<T> v,std::complex<T> *M){
 	M->real(m.real()*v.real()-m.imag()*v.imag());
 	M->imag(m.imag()*v.real()+m.real()*v.imag());
 	return 0;
 }
 
 template<class T>
-int inline check_imag(std::complex<double> m,const T v,T *M){
+int inline type_checks(std::complex<double> m,const T v,T *M){
 	(*M) = v*m.real();
 	return (std::abs(m.imag())>1.1e-15 ? 1 : 0);
 

--- a/quspin/basis/basis_general/base_general.py
+++ b/quspin/basis/basis_general/base_general.py
@@ -266,8 +266,7 @@ class basis_general(lattice_basis):
 		row = _np.empty(self._Ns,dtype=self._index_type)
 		ME = _np.empty(self._Ns,dtype=dtype)
 		# print(self._Ns)
-		N_me = self._core.op(row,col,ME,opstr,indx,J,self._basis,self._n,
-			self._basis_begin,self._basis_end,self._N_p)
+		self._core.op(row,col,ME,opstr,indx,J,self._basis,self._n,self._basis_begin,self._basis_end,self._N_p)
 
 		if _np.iscomplexobj(ME):
 			if ME.dtype == _np.complex64:


### PR DESCRIPTION
The idea behind this pull request is to relax the error that is raised when the matrix elements are requested to be real when they end up being complex. The issue is sometimes there are rounding errors that occur when calculating the matrix elements and so inevitably there might be a round off error which is larger than machine precision epsilon. 

This update would also be consistent with how numpy handles casting a complex type to a real type. We use NumPy's 'ComplexWarning'  with a clear message as to what is happening. The reason for using the NumPy warning is so that if the user wants to catch the NumPy warning and treat it as an error then they do not have to modify any existing code to do so. 


So far I have only implemented this in the general_basis classes and only for the Op function.

There are a few things that are open questions about this:

1)  Should we do this for the basis_1d classes?
2) Should we do this for inplace_Op, Op_bra_ket, etc.
