### PR TITLE
fixing doc; only large int dtypes cause a warning; required sphinx ve…

### DIFF
--- a/quspin/basis/basis_1d/fermion.py
+++ b/quspin/basis/basis_1d/fermion.py
@@ -173,7 +173,8 @@ class spinful_fermion_basis_1d(spinless_fermion_basis_1d,basis_1d):
 	Notes
 	-----
 
-	* The `spinful_fermion_basis` operator strings are separated by a pipe symbol, |, to distinguish the spin-up from spin-down species. However, the index array has NO pipe symbol.
+	* The `spinful_fermion_basis` operator strings are separated by a pipe symbol, "|", to distinguish the spin-up from spin-down species. However, the index array has NO pipe symbol.
+	
 	* Particle-hole like symmetries for fermions can be programmed using the `spinful_fermion_basis_general` class.
 
 
@@ -375,7 +376,7 @@ class spinful_fermion_basis_1d(spinless_fermion_basis_1d,basis_1d):
 
 	@property
 	def N(self):
-		"""int: Total number of sites (spin-up + spin-down) the basis is constructed with. NOTE: :math:`N=2L`."""
+		"""int: Total number of sites (spin-up + spin-down) the basis is constructed with; `N=2L`."""
 		return 2*self._L
 
 	@property

--- a/quspin/basis/basis_general/__init__.py
+++ b/quspin/basis/basis_general/__init__.py
@@ -5,6 +5,8 @@ from ._basis_general_core import (bitwise_not, bitwise_and, bitwise_or, bitwise_
 									bitwise_leftshift, bitwise_rightshift, basis_zeros,basis_ones,
 									python_int_to_basis_int, basis_int_to_python_int, get_basis_type,
 									uint32, uint64, uint256, uint1024, uint4096, uint16384)
+
+
 __all__=["spin_basis_general","boson_basis_general",
  			"spinless_fermion_basis_general","spinful_fermion_basis_general",
  			"bitwise_not","bitwise_and","bitwise_or","bitwise_xor","bitwise_leftshift","bitwise_rightshift",

--- a/quspin/basis/basis_general/base_general.py
+++ b/quspin/basis/basis_general/base_general.py
@@ -428,8 +428,8 @@ class basis_general(lattice_basis):
 
 		Notes
 		-----
-		* particularly useful when a given operation canot be carried out in the symmetry-reduced basis
-		in a straightforward manner.
+		* particularly useful when a given operation canot be carried out in the symmetry-reduced basis in a straightforward manner.
+		
 		* see also `Op_shift_sector()`.
 
 		Parameters

--- a/quspin/basis/basis_general/fermion.py
+++ b/quspin/basis/basis_general/fermion.py
@@ -266,7 +266,7 @@ class spinful_fermion_basis_general(spinless_fermion_basis_general):
 	For instance, if :math:`Q=P` is parity (reflection), then :math:`q=0,1`. If :math:`Q=T` is translation by one lattice site, then :math:`q` labels the mometum blocks in the same fashion as for the `..._basis_1d` classes. 
 
 	User-defined symmetries with the `spinful_fermion_basis_general` class can be programmed in two equivalent ways: *simple* and *advanced*.
-		* *simple* symmetry definition (see optional argument `simple_symm`) uses the pipe symbol, |, in the operator string (see site-coupling lists in example below) to distinguish between the spin-up and spin-down species. Suppose we have a system of L sites. In the *simple* case, the lattice sites are enumerated :math:`s=(s_0,s_1,\\dots,s_{L-1})` for **both** spin-up and spin-down. There are two types of operations one can perform on the sites:
+		* *simple* symmetry definition (see optional argument `simple_symm`) uses the pipe symbol, "|", in the operator string (see site-coupling lists in example below) to distinguish between the spin-up and spin-down species. Suppose we have a system of L sites. In the *simple* case, the lattice sites are enumerated :math:`s=(s_0,s_1,\\dots,s_{L-1})` for **both** spin-up and spin-down. There are two types of operations one can perform on the sites:
 			* exchange the labels of two sites: :math:`s_i \\leftrightarrow s_j` (e.g., translation, parity)
 			* invert the **fermion spin** on a given site: :math:`s_i\\leftrightarrow -(s_j+1)` (e.g., fermion spin inversion)
 

--- a/quspin/basis/lattice.py
+++ b/quspin/basis/lattice.py
@@ -56,14 +56,14 @@ class lattice_basis(basis):
 
 		Notes
 		-----
-		This function is the einverse of `state_to_int`.
+		This function is the inverse of `state_to_int`.
 
 		Parameters
 		-----------
 		state : int
 			Defines the Fock state in integer representation in underlying lattice `basis`.
 		bracket_notation : bool, optional
-			Toggles whether to return the state in |str> notation.
+			Toggles whether to return the state in `|str>` notation.
 
 		Returns
 		--------

--- a/quspin/basis/tensor.py
+++ b/quspin/basis/tensor.py
@@ -19,8 +19,7 @@ __all__=["tensor_basis"]
 class tensor_basis(basis):
 	"""Constructs basis in tensor product Hilbert space.
 
-		The `tensor_basis` class combines two basis objects `basis1` and `basis2` together into a new basis 
-		object which can be then used, e.g., to create the Hamiltonian over the tensor product Hilbert space:
+		The `tensor_basis` class combines two basis objects `basis1` and `basis2` together into a new basis object which can be then used, e.g., to create the Hamiltonian over the tensor product Hilbert space:
 
 		.. math::
 			\\mathcal{H}=\\mathcal{H}_1\\otimes\\mathcal{H}_2
@@ -28,12 +27,9 @@ class tensor_basis(basis):
 		Notes
 		-----
 
-		* The `tensor_basis` operator strings are separated by a pipe symbol, '|'. However, the index array has
-		NO pipe symbol.
+		* The `tensor_basis` operator strings are separated by a pipe symbol, "|". However, the index array has NO pipe symbol.
 
-		* If two fermion basis constructors are used, `tensor_basis` will assume that the two fermion species are distinguishable, 
-		i.e. their operators will commute (instead of anti-commute). For anticommuting fermion species, use the 
-		`spinful_fermion_basis_`* constructors.
+		* If two fermion basis constructors are used, `tensor_basis` will assume that the two fermion species are distinguishable, i.e. their operators will commute (instead of anti-commute). For anticommuting fermion species, use the `spinful_fermion_basis_*` constructors.
 
 		The `tensor_basis` class does not allow one to make use of symmetries, save for particle conservation.
 

--- a/quspin/operators/hamiltonian_core.py
+++ b/quspin/operators/hamiltonian_core.py
@@ -510,11 +510,10 @@ class hamiltonian(object):
 
 	@property
 	def dynamic(self):
-		"""dict: contains dynamic parts of the operator as `{func: Hdyn}`.
+		"""dict: contains dynamic parts of the operator as `dict(func=Hdyn)`. 
 
-		Here `func` is the memory address of the time-dependent function which can be called as `func(time)`.
-		The function arguments are hard-coded, and are not passed. `Hdyn` is the sparse matrix to which
-		the drive couples.
+		The key `func` is the memory address of the time-dependent function which can be called as `func(time)`. The function arguments are hard-coded, and are not passed. 
+		The value `Hdyn` is the sparse matrix to which the drive couples.
 		
 		"""
 		return self._dynamic
@@ -531,6 +530,7 @@ class hamiltonian(object):
 
 	@property
 	def nbytes(self):
+		"""float: Total bytes consumed by the elements of the `hamiltonian` array."""
 		nbytes = 0
 		if _sp.issparse(self._static):
 			nbytes += self._static.data.nbytes

--- a/quspin/operators/quantum_operator_core.py
+++ b/quspin/operators/quantum_operator_core.py
@@ -45,7 +45,7 @@ class quantum_operator(object):
 		It is often required to be able to handle a parameter-dependent Hamiltonian :math:`H(\\lambda)=H_1 + \\lambda H_2`, e.g.
 
 		.. math::
-			H_1=\sum_j J_{zz}S^z_jS^z_{j+1} + h_xS^x_j, \\qquad H_2=\\sum_j S^z_j
+			H_1=\\sum_j J_{zz}S^z_jS^z_{j+1} + h_xS^x_j, \\qquad H_2=\\sum_j S^z_j
 
 		The following code snippet shows how to use the `quantum_operator` class to vary the parameter :math:`\\lambda`
 		without having to re-build the Hamiltonian every time.
@@ -294,6 +294,7 @@ class quantum_operator(object):
 	
 	@property
 	def shape(self):
+		"""tuple: shape of the `quantum_operator` object, always equal to `(Ns,Ns)`."""
 		return self._shape
 	
 

--- a/quspin/tools/expm_multiply_parallel_core/csr_matvec_core.py
+++ b/quspin/tools/expm_multiply_parallel_core/csr_matvec_core.py
@@ -5,43 +5,9 @@ import os
 
 
 def csr_matvec(A,v,a=None,out=None,overwrite_out=True):
-	"""Calculates matrix vector products :math:`x += a A y` or :math:`x = a A y` with csr matrix.
+	"""DEPRICATED (cf `matvec`). Calculates matrix vector products :math:`x += a A y` or :math:`x = a A y` with csr matrix.
 
-	**This function is DEPRICATED** starting from QuSpin 0.3.1.
-
-	Notes
-	-----
-	* For QuSpin builds which support OpenMP this function will be multithreaded. 
-	* Using `out=v` will result in incorrect results. 
-	* If format of A is not 'csr' the matrix will be converted to `csr` format.
-
-	Examples
-	--------
-
-	Parameters
-	-----------
-	A : scipy.spmatrix
-		Sparse matrix to take the dot product. 
-	v : array_like
-		array which contains the vector to take the product with. 
-	a : scalar, optional
-		value to scale the vector with after the product with `A` is taken.
-	out : array_like
-		output array to put the results of the calculation.
-	overwrite_out : bool, optional
-		If set to `True`, the function overwrites the values in `out` with the result. otherwise the result is
-		added to the values in `out`. 
-
-	Returns
-	--------
-	numpy.ndarray
-		result of :math:`a A v`. 
-
-		If `out` is not None and `overwrite_out = True` the dunction returns `out` with the data overwritten, 
-		otherwise if `overwrite_out = False` the result is added to `out`.
-
-		If `out` is None the result is stored in a new array which is returned by the function. 
-	
+	:red:`Note: we recommend the use of "tools.misc.matvec()" instead of this function. This function is now deprecated!`
 
 	"""
 	if not issparse(A):

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -26,44 +26,67 @@ sys.path.insert(0, os.path.abspath('../../'))
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+# needs_sphinx = '3.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
+extensions = [
+
               'sphinx.ext.mathjax',
+
+              'numpydoc',
+
+              'sphinx.ext.autodoc',
+              
               'sphinx.ext.intersphinx',
               'sphinx.ext.coverage',
               'sphinx.ext.autosummary',
               'sphinx.ext.viewcode',
-      #        'sphinx.ext.autosectionlabel', # doesn't seem to work
+          #    'sphinx.ext.autosectionlabel', # doesn't seem to work
+      
               'sphinxtogithub',
-              'numpydoc',
+              'sphinx.ext.napoleon',
               'sphinxcontrib.googleanalytics',
 
-              'sphinx.ext.napoleon',
-              'sphinx_automodapi.automodapi',
-
-              'sphinx.ext.doctest',
-              # 'sphinx.ext.todo',
-              # 'sphinx.ext.imgmath',
             ]
 
 
 # -- General configuration ------------------------------------------------
 # autoclass_content = ""  
-autodoc_default_flags = [
-        # Make sure that any autodoc declarations show the right members
-        "members",
-        "inherited-members",
-        "show-inheritance"
-        "no-special-members",
-        "no-private-members",
-        "no-undoc-members"
-]
+# autodoc_default_flags = [
+#         # Make sure that any autodoc declarations show the right members
+#         "members",
+#         "inherited-members",
+#         "show-inheritance",
+#         "no-special-members",
+#         "no-private-members",
+#         "no-undoc-members"
+# ]
+
+autodoc_default_options = {
+        "members": True,
+        "inherited-members": True,
+        "show-inheritance": True,
+        "no-special-members": True,
+        "no-private-members": True,
+        "no-undoc-members": True,
+
+      #  'member-order': 'bysource',
+        'undoc-members': True,
+        'exclude-members': '__init__',
+}
 
 autosummary_generate = True  # Make _autosummary files and include them
+
+# Only the class' docstring is inserted.
+autoclass_content = 'class'
+
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = False
+ 
+# remove duplicates 
+numpydoc_show_class_members = False
 
 # # NumPydoc settings
 # numpydoc_show_class_members = True
@@ -130,7 +153,8 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns =  [] #['_build', 'Thumbs.db', '.DS_Store', '.git']
+#exclude_patterns =  [] #['_build', 'Thumbs.db', '.DS_Store', '.git']
+#exclude_patterns = ['links.rst', 'README.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -14,7 +14,7 @@ Check out these papers for a detailed tutorial:
     * `SciPost Phys. 2, 003 (2017) <https://scipost.org/SciPostPhys.2.1.003>`_.
     * `SciPost Phys. 7, 020 (2019) <https://scipost.org/SciPostPhys.7.2.020>`_.
 
-The source code is available on `Github <https://github.com/weinbe58/QuSpin/tree/master>`_; report any bugs `here <https://github.com/weinbe58/QuSpin/issues>`_. Suggestions for improvement and user contributions and are welcome!
+The source code is available on `Github <https://github.com/weinbe58/QuSpin/tree/master>`_; **report any bugs** `here <https://github.com/weinbe58/QuSpin/issues>`_. Suggestions for improvement and user contributions are welcome!
 
 
 New Features


### PR DESCRIPTION
-- updating doc; requires sphinx 3.0
-- removed doubling of methods and attributes
-- compatibility with sphinx 3.0

#374 