### PR TITLE
quantum_operator `tohamiltonian` copy option.

### DIFF
--- a/quspin/operators/quantum_operator_core.py
+++ b/quspin/operators/quantum_operator_core.py
@@ -1050,7 +1050,7 @@ class quantum_operator(object):
 		rmatvec = functools.partial(_quantum_operator_dot,self.H,pars)
 		return _sla.LinearOperator(self.get_shape,matvec,rmatvec=rmatvec,matmat=matvec,dtype=self._dtype)		
 
-	def tohamiltonian(self,pars={}):
+	def tohamiltonian(self,pars={},copy=True):
 		"""Returns copy of a `quantum_operator` object for parameters `pars` as a `hamiltonian` object.
 
 		Parameters
@@ -1058,6 +1058,9 @@ class quantum_operator(object):
 		pars : dict, optional
 			Dictionary with same `keys` as `input_dict` and coupling strengths as `values`. Any missing `keys`
 			are assumed to be set to unity.
+		
+		copy : bool, optional
+			Explicitly copy matrices when constructing the `hamiltonian` object, default is `True`.
 
 		Returns
 		--------
@@ -1065,7 +1068,7 @@ class quantum_operator(object):
 
 		Examples
 		---------
-		>>> H_aslinop=H.tohamiltonian(pars=pars)
+		>>> H_ham=H.tohamiltonian(pars=pars)
 
 		"""
 		pars = self._check_hamiltonian_pars(pars)
@@ -1082,7 +1085,7 @@ class quantum_operator(object):
 				else:
 					static.append(J*self._quantum_operator[key])
 
-		return hamiltonian_core.hamiltonian(static,dynamic,dtype=self._dtype)
+		return hamiltonian_core.hamiltonian(static,dynamic,dtype=self._dtype,copy=copy)
 
 	def update_matrix_formats(self,matrix_formats):
 		"""Change the internal structure of the matrices in-place.


### PR DESCRIPTION
Add optional argument that prevents coping of data when constructing a Hamiltonian object out of a quantum_operator. 